### PR TITLE
Made `name` public

### DIFF
--- a/src/exp/ecs/entity/Entity.hx
+++ b/src/exp/ecs/entity/Entity.hx
@@ -5,14 +5,14 @@ using tink.CoreApi;
 
 class Entity {
 	
+	public var name:String;
 	public var id(default, null):Int;
 	public var componentAdded:Signal<Component>;
 	public var componentRemoved:Signal<Component>;
 	
 	var components:Map<ComponentType, Component>;
 	var componentAddedTrigger:SignalTrigger<Component>;
-	var componentRemovedTrigger:SignalTrigger<Component>;
-	var name:String;
+	var componentRemovedTrigger:SignalTrigger<Component>;	
 	
 	static var ids:Int = 0;
 	


### PR DESCRIPTION
As far as I can see this variable should be usable in a public manner, otherwise I'm not sure what the intended purpose for this var is meant to be